### PR TITLE
Fix callbacks on Android

### DIFF
--- a/src/android/com/pushbots/plugin/PushbotsPlugin.java
+++ b/src/android/com/pushbots/plugin/PushbotsPlugin.java
@@ -24,12 +24,13 @@ import java.util.Set;
 
 public class PushbotsPlugin extends CordovaPlugin {
 
+	// _callbackContext is saved from initialize
 	private static CallbackContext _callbackContext;
 	public static CordovaWebView gwebView;
 	public static Activity mActivity;
 
 	@Override
-	public boolean execute(final String action,final JSONArray args, final CallbackContext cb) throws JSONException {
+	public boolean execute(final String action, final JSONArray args, final CallbackContext cb) throws JSONException {
 
 		gwebView = this.webView;
 		mActivity = cordova.getActivity();
@@ -107,80 +108,69 @@ public class PushbotsPlugin extends CordovaPlugin {
                         e.printStackTrace();
                     }
                 }
-				noResult();
 			}
 		});
 	}
 
-	private void _updateAlias(JSONArray args, CallbackContext cb) throws JSONException {
+	private void _updateAlias(JSONArray args, final CallbackContext cb) throws JSONException {
 
 		final String alias = args.getString(0);
-
-		_callbackContext = cb;
 
 		cordova.getActivity().runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
 				Pushbots.sharedInstance().setAlias(alias);
-				noResult();
+				cb.success("");
 			}
 		});
 	}
 
-	private void _tag(JSONArray args, CallbackContext cb) throws JSONException {
+	private void _tag(JSONArray args, final CallbackContext cb) throws JSONException {
 
 		final String tag = args.getString(0);
-
-		_callbackContext = cb;
 
 		cordova.getActivity().runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
 				Pushbots.sharedInstance().tag(tag);
-				noResult();
+				cb.success("");
 			}
 		});
 	}
 
-	private void _untag(JSONArray args, CallbackContext cb) throws JSONException {
+	private void _untag(JSONArray args, final CallbackContext cb) throws JSONException {
 
 		final String tag = args.getString(0);
-
-		_callbackContext = cb;
 
 		cordova.getActivity().runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
 				Pushbots.sharedInstance().untag(tag);
-				noResult();
+				cb.success("");
 			}
 		});
 	}
 
-	private void _debug(JSONArray args, CallbackContext cb) throws JSONException {
+	private void _debug(JSONArray args, final CallbackContext cb) throws JSONException {
 
 		final Boolean debug = args.getBoolean(0);
-
-		_callbackContext = cb;
 
 		cordova.getActivity().runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
 				Pushbots.sharedInstance().debug(debug);
-				noResult();
+				cb.success("");
 			}
 		});
 	}
 
-	private void _unregister(JSONArray args, CallbackContext cb) throws JSONException {
-
-		_callbackContext = cb;
+	private void _unregister(JSONArray args, final CallbackContext cb) throws JSONException {
 
 		cordova.getActivity().runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
 				Pushbots.sharedInstance().unRegister();
-				noResult();
+				cb.success("");
 			}
 		});
 	}
@@ -203,17 +193,4 @@ public class PushbotsPlugin extends CordovaPlugin {
 			}
 		}
 	}
-
-	public static void fail(String message) {
-		PluginResult result = new PluginResult(PluginResult.Status.ERROR, message);
-		result.setKeepCallback(true);
-		_callbackContext.sendPluginResult(result);
-	}
-
-	private static void noResult(){
-		PluginResult result = new PluginResult(PluginResult.Status.OK, "");
-		result.setKeepCallback(true);
-		_callbackContext.sendPluginResult(result);
-	}
-
 }

--- a/www/pushbots.js
+++ b/www/pushbots.js
@@ -118,7 +118,7 @@ PushbotsPlugin.prototype.fire = function (eventName, data) {
 * @param {string} alias
 */
 PushbotsPlugin.prototype.updateAlias = function(alias){
-	exec(this.success, this.fail, SERVICE_TITLE, 'updateAlias', [alias]);
+	exec(undefined, undefined, SERVICE_TITLE, 'updateAlias', [alias]);
 };
 
 /**
@@ -127,7 +127,7 @@ PushbotsPlugin.prototype.updateAlias = function(alias){
 * @param {string} tag
 */
 PushbotsPlugin.prototype.tag = function(tag){
-	exec(this.success, this.fail, SERVICE_TITLE, 'tag', [tag]);
+	exec(undefined, undefined, SERVICE_TITLE, 'tag', [tag]);
 };
 
 /**
@@ -136,7 +136,7 @@ PushbotsPlugin.prototype.tag = function(tag){
 *
 */
 PushbotsPlugin.prototype.resetBadge = function(){
-	exec(this.success, this.fail, SERVICE_TITLE, 'clearBadgeCount', []);
+	exec(undefined, undefined, SERVICE_TITLE, 'clearBadgeCount', []);
 };
 
 
@@ -146,7 +146,7 @@ PushbotsPlugin.prototype.resetBadge = function(){
 *
 */
 PushbotsPlugin.prototype.setBadge = function(badge){
-	exec(this.success, this.fail, SERVICE_TITLE, 'setBadge', [badge]);
+	exec(undefined, undefined, SERVICE_TITLE, 'setBadge', [badge]);
 };
 
 /**
@@ -155,7 +155,7 @@ PushbotsPlugin.prototype.setBadge = function(badge){
 * @param {string} tag
 */
 PushbotsPlugin.prototype.untag = function(tag){
-	exec(this.success, this.fail, SERVICE_TITLE, 'untag', [tag]);
+	exec(undefined, undefined, SERVICE_TITLE, 'untag', [tag]);
 };
 
 /**
@@ -164,7 +164,7 @@ PushbotsPlugin.prototype.untag = function(tag){
 * @param {boolean} debug
 */
 PushbotsPlugin.prototype.debug = function(debug){
-	exec(this.success, this.fail, SERVICE_TITLE, 'debug', [debug]);
+	exec(undefined, undefined, SERVICE_TITLE, 'debug', [debug]);
 };
 
 /**
@@ -173,7 +173,7 @@ PushbotsPlugin.prototype.debug = function(debug){
 * @param {callback} success
 */
 PushbotsPlugin.prototype.getRegistrationId = function(success){
-	exec(success, this.fail, SERVICE_TITLE, 'getRegistrationId', []);
+	exec(success, undefined, SERVICE_TITLE, 'getRegistrationId', []);
 };
 
 /**
@@ -182,7 +182,7 @@ PushbotsPlugin.prototype.getRegistrationId = function(success){
 * @param {callback} success
 */
 PushbotsPlugin.prototype.unregister = function(){
-	exec(this.success, this.fail, SERVICE_TITLE, 'unregister', []);
+	exec(undefined, undefined, SERVICE_TITLE, 'unregister', []);
 };
 
 if(!window.plugins)


### PR DESCRIPTION
Changes to Java API:
Overwriting the _callbackContext with every call is unnecessary (and breaks the implementation with the current javascript interface). Instead the context is stored once when calling initialize and used every time a notification is received or opened.

Changes to javascript interface:
The success and fail callbacks are referenced in every api-call (this.success/this.fail), but do not exist. One could keep the current Java API and bind the success and fail from initialize to this, but then we would still unnecessarily overwrite _callbackContext with every call.
